### PR TITLE
Jk attach tab

### DIFF
--- a/vahs/app/assets/javascripts/508ARIA.js
+++ b/vahs/app/assets/javascripts/508ARIA.js
@@ -1,34 +1,34 @@
 
 $( document ).ready(function() {
-	/* 508 Append ARIA tags using the 'alt' attribute */
+	/* 508 Append ARIA label tags using the 'alt' attribute */
 
 	$.each($('a'), function(k,obj){
 		var alt = $(obj).attr('alt');
-		$(obj).attr('title',alt).attr('aria-label',alt).attr('aria-describedby',alt).attr('aria-labelledby',alt);
+		$(obj).attr('title',alt).attr('aria-label',alt);
 	});
 
 	$.each($('select'), function(k,obj){
 		var alt = $(obj).attr('alt');
-		$(obj).attr('title',alt).attr('aria-label',alt).attr('aria-describedby',alt).attr('aria-labelledby',alt);
+		$(obj).attr('title',alt).attr('aria-label',alt);
 	});
 
 	$.each($('label'), function(k,obj){
 		var alt = $(obj).attr('alt');
-		$(obj).attr('title',alt).attr('aria-label',alt).attr('aria-describedby',alt).attr('aria-labelledby',alt);
+		$(obj).attr('title',alt).attr('aria-label',alt);
 	});
 
 	$.each($('input'), function(k,obj){
 		var alt = $(obj).attr('alt');
-		$(obj).attr('title',alt).attr('aria-label',alt).attr('aria-describedby',alt).attr('aria-labelledby',alt);
+		$(obj).attr('title',alt).attr('aria-label',alt);
 	});
 
 	$.each($('button'), function(k,obj){
 		var alt = $(obj).attr('alt');
-		$(obj).attr('title',alt).attr('aria-label',alt).attr('aria-describedby',alt).attr('aria-labelledby',alt);
+		$(obj).attr('title',alt).attr('aria-label',alt);
 	});
 
 	$.each($('img'), function(k,obj){
 		var alt = $(obj).attr('alt');
-		$(obj).attr('title',alt).attr('aria-label',alt).attr('aria-describedby',alt).attr('aria-labelledby',alt);
+		$(obj).attr('title',alt).attr('aria-label',alt);
 	});
 });

--- a/vahs/app/assets/stylesheets/employee.scss
+++ b/vahs/app/assets/stylesheets/employee.scss
@@ -90,3 +90,8 @@ li.ui-state-active {
 div.accordion h3.ui-state-active {
   background-color: #0074e8 !important;
 }
+
+div.tab-panel > div.attachments {
+  overflow-x: scroll;
+  width: 660px;
+}

--- a/vahs/app/controllers/rms/attachment_controller.rb
+++ b/vahs/app/controllers/rms/attachment_controller.rb
@@ -1,11 +1,44 @@
 class Rms::AttachmentController < Rms::ApplicationController
   before_filter :verify_access
 
+  def edit
+    @attachment = Bvadmin::RmsAttachment.find(params[:id])
+
+    respond_to do |format|
+      format.html { render partial: '/rms/employee/attachment/edit' }
+      format.js { render 'rms/attachment/edit' }
+    end
+
+  rescue Exception
+    flash[:error] = { "#{params[:id]}": "Attachment does not exist." }
+    respond_to do |format|
+      format.html { redirect_to :back }
+      format.js { render 'rms/employee/errors' }
+    end
+  end
+
+  def delete
+    attachment = Bvadmin::RmsAttachment.find(params[:id])
+    attachment.destroy
+
+    respond_to do |format|
+      flash[:notice] = 'Attachment removed successfully'
+      format.js { render 'rms/attachment/delete' }
+    end
+
+  rescue Exception
+    flash[:error] = { "#{params[:id]}": "File does not exist" }
+    respond_to do |format|
+      format.html { redirect_to :back }
+      format.js { render 'rms/attachment/delete_error' }
+    end
+  end
+
   def download
     attachment = Bvadmin::RmsAttachment.find(params[:id])
     send_data attachment.filedata, filename: attachment.filename,
                                    type: attachment.filetype,
-                                   disposition: 'attachment'
+                                   disposition: 'inline'
 
   rescue Exception
     flash[:error] = { "#{params[:id]}": "File does not exist" }

--- a/vahs/app/models/bvadmin/employee.rb
+++ b/vahs/app/models/bvadmin/employee.rb
@@ -157,7 +157,7 @@ class Bvadmin::Employee < Bvadmin::Record
                                         filetype: attachment[:attachment].content_type,
                                         filedata: attachment[:attachment].read,
                                         notes: attachment[:notes],
-                                        date: Date.today)
+                                        str_date: attachment[:date] || Date.today.strftime("%Y-%m-%d"))
 
     if attach.valid?
       attach.save
@@ -168,6 +168,40 @@ class Bvadmin::Employee < Bvadmin::Record
     end
   end
   
+  def save_attachments attachments
+    return if attachments.nil? || attachments.empty?
+
+    attachments.each do |attachment|
+      # maybe this is kind of ugly, and not the correct place to do this?
+      attachment[:date] = Date.today.strftime("%Y-%m-%d") if attachment[:date].blank?
+
+      save_attachment attachment
+    end
+  end
+
+  def edit_attachments attachments
+    return if attachments.nil? || attachments.empty?
+
+    attachments.each do |id, attachment|
+      attach = Bvadmin::RmsAttachment.find_by(id: id)
+      if attach.nil?
+        errors.add "Attachment.#{id}", "Invalid ID"
+        next
+      end
+
+      attach.update_attributes(attachment_type: attachment[:attachment_type],
+                               filename: attachment[:filename],
+                               notes: attachment[:notes],
+                               str_date: attachment[:date])
+
+      if attach.valid?
+        attach.save
+      else
+        append_errors 'Attachment', attach
+      end
+    end
+  end
+
   def save_award award
 	return nil if award.nil?
 	
@@ -188,7 +222,8 @@ class Bvadmin::Employee < Bvadmin::Record
   end
 
   def save_status status
-    return nil if status.nil?
+    return nil if status.nil? || status.empty? || status[:status_type].blank?
+
     output= Bvadmin::RmsStatusInfo.new(employee_id: self.employee_id,
                                            status_type: status[:status_type],
                                            rolls_date: status[:rolls_date],

--- a/vahs/app/models/bvadmin/rms_attachment.rb
+++ b/vahs/app/models/bvadmin/rms_attachment.rb
@@ -1,5 +1,50 @@
 class Bvadmin::RmsAttachment < Bvadmin::Record
   self.table_name = "BVADMIN.RMS_ATTACHMENTS"
 
+  attr_writer :str_date
+
   belongs_to :employee
+
+  validate :str_date_is_valid
+
+  validates :employee_id, presence: true
+  validates :date, presence: true
+  validates :filename, presence: true
+  validates :filetype, presence: true
+  validates :attachment_type, presence: true
+  validates :filedata, presence: true
+
+
+  def date= date
+    return super(date) unless date.is_a? String
+
+    date = Date.strptime(date, "%m%d%Y") if date =~ /\d{8}/
+    date = Date.strptime(date, "%m/%d/%Y") if date =~ /\d{1,2}\/\d{1,2}\/\d{4}/
+    date = Date.parse(date) if date =~ /\d{4}-\d{1,2}-\d{1,2}/
+
+    super date
+  end
+
+  def str_date
+    @str_date || self.date.to_s
+  end
+
+  def str_date_is_valid
+    return if @str_date.blank?
+
+    unless @str_date =~ /^(\d{8}|\d{1,2}\/\d{1,2}\/\d{4}|\d{4}-\d{1,2}-\d{1,2})$/
+      errors.add :date, 'invalid date format supplied, accepted forms are: YYYY-MM-DD, MMDDYYYY, and MM/DD/YYYY'
+      return
+    end
+
+    if @str_date =~ /^\d{8}$/
+      tmp = Date.strptime(@str_date, "%m%d%Y")
+    elsif @str_date =~ /^\d{1,2}\/\d{1,2}\/\d{4}$/
+      tmp = Date.strptime(@str_date, "%m/%d/%Y") 
+    else
+      tmp = Date.strptime(@str_date, "%Y-%m-%d") 
+    end
+
+    self.date = tmp
+  end
 end

--- a/vahs/app/views/rms/attachment/delete.js.erb
+++ b/vahs/app/views/rms/attachment/delete.js.erb
@@ -1,0 +1,10 @@
+$('#flash-alert').remove();
+$('<div class="flash-banner alert alert-info" id="flash-alert"></div>').insertAfter('#subheader')
+$('#flash-alert').append("<%= flash[:notice] || '' %>")
+
+<% flash.clear %>
+
+$('#attach-files #at<%= params[:id] %>').remove();
+
+window.scrollTo(0,0);
+$('#flash-alert').fadeOut(5000);

--- a/vahs/app/views/rms/attachment/delete_error.js.erb
+++ b/vahs/app/views/rms/attachment/delete_error.js.erb
@@ -1,0 +1,12 @@
+$('#flash-alert').remove();
+$('<div class="flash-banner alert alert-info" id="flash-alert"></div>').insertAfter('#subheader')
+
+$('#flash-alert').append("<ul>")
+<% (flash[:error] || {}).each do |key, err| %>
+  $('#flash-alert').append('<li><b><%= key %></b>: <%= err %></li>')
+<% end %>
+$('#flash-alert').append('</ul>')
+
+<% flash.clear %>
+
+window.scrollTo(0,0);

--- a/vahs/app/views/rms/attachment/edit.js.erb
+++ b/vahs/app/views/rms/attachment/edit.js.erb
@@ -1,0 +1,8 @@
+$('#attach-files #at<%= params[:id] %>').empty();
+$('#attach-files #at<%= params[:id] %>').append("<%= j render 'rms/employee/attachment/edit' %>");
+$('.datefield').datepicker({
+  changeMonth: true,
+  changeYear: true,
+  showButtonPannel: true,
+  dateFormat: 'mm/dd/yy'
+});

--- a/vahs/app/views/rms/employee/_attachments.html.erb
+++ b/vahs/app/views/rms/employee/_attachments.html.erb
@@ -1,49 +1,32 @@
 <h2>Employee Records</h2>
 
 <div class="tab-panel">
-  <div class="accordion">
-    <h3><a href="#" alt="Upload Attachment">Upload Attachment</a></h3>
-    <div class="accordion-selection">
-      <div class="fieldset-left">
-        <%= label_tag :attachment_type, "Document Type:" %>
-        <%= select_tag :attachment_type, options_for_select(Bvadmin::RmsDropDownConfig.options_for(:attachment, :attachment_type)), name: 'attachment[attachment_type]' %>
-      </div>
-
-      <br /><br />
-
-      <div class="fieldset-left">
-        <%= label_tag :attachment_filename, "Filename:" %>
-        <%= file_field_tag :attachment_filename, size: 60, name: 'attachment[attachment]' %>
-      </div>
-
-      <br /><br />
-
-      <div class="fieldset-left">
-        <%= label_tag :attachment_notes, "Notes:" %>
-        <%= text_area_tag :attachment_notes, "", name: 'attachment[notes]', rows: 6, cols: 100 %>
-      </div>
-    </div>
-
-    <h3><a href="#" alt="Employee Attachments">Employee Attachments</a></h3>
-    <div class="accordion-section">
-      <table cellpadding="10" class="table table-condensed employee-attachments">
-        <thead>
-          <tr>
-            <th>Type</th>
-            <th>Filename</th>
-            <th>Notes</th>
-          </tr>
-        </thead>
-        <tbody>
+  <div class="attachments">
+    <table cellpadding="10" class="table table-condensed employee-attachments">
+      <thead>
+        <tr>
+          <th id="atchhdr_actions">Actions</th>
+          <th id="atchhdr_date">Date</th>
+          <th id="atchhdr_type">Type</th>
+          <th id="atchhdr_filename">Filename</th>
+          <th id="atchhdr_notes">Notes</th>
+        </tr>
+      </thead>
+      <tbody id="attach-files">
+        <%= render partial: '/rms/employee/attachment/upload' %>
         <% @employee.attachments.each do |attachment| %>
-          <tr>
+          <tr id="at<%= attachment.id %>">
+            <td>
+              <%= link_to 'Edit', "/rms/employee/attachment/#{attachment.id}/edit", remote: true, 'aria-label': "Edit #{attachment.attachment_type} document named #{attachment.filename}" %><br>
+              <%= link_to 'Delete', "/rms/employee/attachment/#{attachment.id}/delete", remote: true, 'data-confirm': "Are you sure you want to delete '#{attachment.filename}'?", 'aria-label': "Delete #{attachment.filename}" %>
+            </td>
+            <td><%= attachment.date %></td>
             <td><%= attachment.attachment_type %></td>
-            <td><a href="/rms/attachment/<%= attachment.id %>" alt="<%= attachment.filename %>" aria-label="Download attachment <%= attachment.attachment_type %> as <%= attachment.filename %>"><%= attachment.filename %></a></td>
+            <td><a href="/rms/attachment/<%= attachment.id %>" alt="Download <%= attachment.filename %>" aria-label="Download attachment <%= attachment.attachment_type %> as <%= attachment.filename %>" target="_blank"><%= attachment.filename %></a></td>
             <td><%= attachment.notes %></td>
           </tr>
         <% end %>
-        </tbody>
-      </table>
-    </div>
+      </tbody>
+    </table>
   </div>
 </div>

--- a/vahs/app/views/rms/employee/attachment/_edit.html.erb
+++ b/vahs/app/views/rms/employee/attachment/_edit.html.erb
@@ -1,0 +1,7 @@
+<%= fields_for 'eattachment[]', @attachment, include_id: false do |attach_form| %>
+  <td></td>
+  <td><%= attach_form.text_field :date, size: 8, class: 'datefield', id: "date-at#{@attachment.id}" %></td>
+  <td><%= attach_form.select :attachment_type, options_for_select(Bvadmin::RmsDropDownConfig.options_for(:attachment, :attachment_type)), {}, { id: "type-at#{@attachment.id}" } %></td>
+  <td><%= attach_form.text_field :filename, id: "filename-at#{@attachment.id}" %></td>
+  <td><%= attach_form.text_area :notes, id: "notes-at#{@attachment.id}", rows: 3, cols: 45 %></td>
+<% end %>

--- a/vahs/app/views/rms/employee/attachment/_upload.html.erb
+++ b/vahs/app/views/rms/employee/attachment/_upload.html.erb
@@ -1,0 +1,9 @@
+<%= fields_for 'attachment[]', Bvadmin::RmsAttachment.new do |attach_form| %>
+  <tr><% id = Random.rand(1..1000) -%>
+    <td><%= link_to 'Add', '/rms/employee/attachment_form', remote: true, 'aria-label': "Add another attachment" %></td>
+    <td><%= attach_form.text_field :date, size: 8, class: 'datefield', id: "ndate-at#{id}", 'aria-labelledby': 'atchhdr_date' %></td>
+    <td><%= attach_form.select :attachment_type, options_for_select(Bvadmin::RmsDropDownConfig.options_for(:attachment, :attachment_type)), {}, { id: "ntype-at#{id}", class: 'attachment-type', 'aria-labelledby': 'atchhdr_type' } %></td>
+    <td><%= attach_form.file_field :attachment, id: "nattachment-at#{id}", 'aria-labelledby': 'atchhdr_filename' %></td>
+    <td><%= attach_form.text_area :notes, id: "nnotes-at#{id}", rows: 3, cols: 45, 'aria-labelledby': 'atchhdr_notes' %></td>
+  </tr>
+<% end %>

--- a/vahs/app/views/rms/employee/attachment/upload.js.erb
+++ b/vahs/app/views/rms/employee/attachment/upload.js.erb
@@ -1,0 +1,11 @@
+$('#attach-files').prepend("<%= j render partial: 'rms/employee/attachment/upload' %>");
+
+/* this needs to be here, so that the new datefield classes
+ * get the datepicker object added to them. */
+$('.datefield').datepicker({
+  changeMonth: true,
+  changeYear: true,
+  showButtonPannel: true,
+  dateFormat: 'mm/dd/yy'
+});
+

--- a/vahs/config/routes.rb
+++ b/vahs/config/routes.rb
@@ -32,6 +32,12 @@ Rails.application.routes.draw do
       get '/picture/(:id)', to: 'employee#picture'
 
       get '/status_select/(:id)', to: 'employee#status_select'
+      get '/attachment_form', to: 'employee#attachment_form'
+
+      scope :attachment do
+        get '/:id/edit', to: 'attachment#edit'
+        get '/:id/delete', to: 'attachment#delete'
+      end
     end
 
     scope :attachment, as: :attachment do

--- a/vahs/spec/feature/employee_attachment_spec.rb
+++ b/vahs/spec/feature/employee_attachment_spec.rb
@@ -26,57 +26,36 @@ RSpec.feature 'Employee Attachment(s)' do
     expect(content).to have_text 'Employee Records'
   end
 
-  it 'should have an accordion for uploading attachments' do
-    expect(content).to have_link 'Upload Attachment'
-  end
-
-  it 'should have an accordion for listing attachments' do
-    expect(content).to have_link 'Employee Attachments'
-  end
-
   it 'should have a select for "Document Type"' do
-    click_link 'Upload Attachment'
-    
-    expect(content).to have_text 'Document Type'
-    expect(content).to have_select :attachment_type
+    expect(content).to have_select 'attachment[][attachment_type]'
   end
 
   it 'should have a place to upload attachments' do
-    click_link 'Upload Attachment'
-
-    expect(content).to have_text 'Filename'
-    expect(content).to have_field 'attachment[attachment]'
+    expect(content).to have_field 'attachment[][attachment]'
   end
 
   it 'should have a place to add notes' do
-    click_link 'Upload Attachment'
-
-    expect(content).to have_text 'Notes'
-    expect(content).to have_field 'attachment[notes]'
+    expect(content).to have_field 'attachment[][notes]'
   end
 
-  scenario 'attach a file' do
+  it 'should let me attach a file' do
     # verify attachment isn't there.
-    click_link "Employee Attachments"
-
     expect(content).to_not have_text 'Other'
     expect(content).to_not have_link 'certificate.png'
     expect(content).to_not have_text 'This is my certificate'
 
     # upload attachment
-    click_link 'Upload Attachment'
-    select 'Other', from: 'attachment[attachment_type]'
-    attach_file 'attachment[attachment]', certificate
-    fill_in 'attachment[notes]', with: 'This is my certificate'
+    select 'Other', from: 'attachment[][attachment_type]'
+    attach_file 'attachment[][attachment]', certificate
+    fill_in 'attachment[][notes]', with: 'This is my certificate'
     find('#save_employee').click
 
     # verify attachment was uploaded.
     expect(page).to have_text 'employee was saved'
 
-    # verify attachment is visible
     click_link 'Employee Records'
-    click_link 'Employee Attachments'
 
+    # verify attachment is available
     expect(content).to have_text 'Other'
     expect(content).to have_link 'certificate.png'
     expect(content).to have_text 'This is my certificate'


### PR DESCRIPTION
Attachments (Round #2)

* Support for editing attachments that have been uploaded.
* Opens attachments in a new tab/window (target=_blank) with disposition 'inline'.
* Support for updating multiple attachments at once.
* Support for editing multiple attachments at once.
* Support for changing the 'upload' date.

This Pull req is mostly just to get the code into eclipse to allow Marz to test it.

I do not 100% know if this is the final iteration of this task. The front-end layout may need to be revisited, but alas, I couldn't think of anything that looked nice. And I could spend hours doing that, or just pass it off and let feedback come in.

Issues I see with this current layout:
  I'm using the table headers as the labels for the fields. (aria-labelledby seems to allow this, but I don't know if that is truly 508 compliant.)
  If the attachments list is really long, having to scroll down to scroll over, to scroll back up could be very annoying.