### PR TITLE
Jk newsearch applicant

### DIFF
--- a/vahs/app/controllers/rms/applicant_controller.rb
+++ b/vahs/app/controllers/rms/applicant_controller.rb
@@ -74,6 +74,25 @@ class Rms::ApplicantController < Rms::ApplicationController
     redirect_to rms_applicant_path
   end
 
+  def delete
+    @applicant = Bvadmin::EmployeeApplicant.find(params[:id])
+    if @applicant.delete
+      flash[:notice] = "#{@applicant.fname} #{@applicant.lname} was deleted."
+    else
+      flash[:notice] = "could not delete #{@applicant.fname} #{@applicant.lname}"
+    end
+
+    @applicants = Bvadmin::PotentialApplicant.newsearch(params.dig(:applicant, :fname),
+                                                        params.dig(:applicant, :lname)).
+                                                        order('FNAME ASC').
+                                                        paginate(per_page: 10, page: params[:page])
+
+    respond_to do |format|
+      format.html { redirect_to :back }
+      format.js
+    end
+  end
+
 private
 
   def verify_access

--- a/vahs/app/controllers/rms/applicant_controller.rb
+++ b/vahs/app/controllers/rms/applicant_controller.rb
@@ -82,11 +82,6 @@ class Rms::ApplicantController < Rms::ApplicationController
       flash[:notice] = "could not delete #{@applicant.fname} #{@applicant.lname}"
     end
 
-    @applicants = Bvadmin::PotentialApplicant.newsearch(params.dig(:applicant, :fname),
-                                                        params.dig(:applicant, :lname)).
-                                                        order('FNAME ASC').
-                                                        paginate(per_page: 10, page: params[:page])
-
     respond_to do |format|
       format.html { redirect_to :back }
       format.js

--- a/vahs/app/views/base/index.html.erb
+++ b/vahs/app/views/base/index.html.erb
@@ -8,7 +8,7 @@
           <ul role="menu">
             <li role="menuitem"><%= auth_link_to "Create Employee Record", rms_employee_new_path, 'aria-label': 'Create an Employee Record' %></li>
             <li role="menuitem"><%= auth_link_to "Modify Employee Record", rms_employee_search_path, 'aria-label': 'Find an Employee and update their record' %></li>
-            <li role="menuitem"><%= auth_link_to "Create Applicant Record", rms_applicant_new_path, 'aria-label': 'Create an Applicant Record' %></li>
+            <li role="menuitem"><%= auth_link_to "Create Applicant Record", rms_applicant_path, 'aria-label': 'Create an Applicant Record' %></li>
           </ul>
         </div>
       </div>

--- a/vahs/app/views/rms/applicant/delete.js.erb
+++ b/vahs/app/views/rms/applicant/delete.js.erb
@@ -1,0 +1,9 @@
+$('#flash-alert').remove();
+
+$('<div class="flash-banner alert alert-info" id="flash-alert"></div>').insertAfter('#subheader')
+$('#flash-alert').append("<%= flash[:notice] || '' %>")
+
+<% flash.clear %>
+
+$('#applicant<%= @applicant.id.to_i -%>').remove();
+$('#flash-alert').fadeOut(5000);

--- a/vahs/app/views/rms/applicant/edit.html.erb
+++ b/vahs/app/views/rms/applicant/edit.html.erb
@@ -1,0 +1,6 @@
+<% title "BVA Resource Management System - Edit Applicant" %>
+<% page_header "Edit Applicant - #{@applicant.lname}, #{@applicant.fname}" %>
+
+<div id="content" class="container">
+  Edit page for <%= @applicant.fname -%> <%= @applicant.lname -%><br>
+</div>

--- a/vahs/app/views/rms/applicant/index/_applicants.html.erb
+++ b/vahs/app/views/rms/applicant/index/_applicants.html.erb
@@ -12,6 +12,10 @@
       <ul class="inline-list">
         <%- if applicant.table == 'app' -%>
         <li><%= link_to 'Edit', "/rms/applicant/#{applicant.id.to_i}/edit", 'aria-label': "Edit Applicant #{applicant.fname} #{applicant.lname}" -%></li>
+        <li><%= link_to 'Delete', "/rms/applicant/#{applicant.id.to_i}", remote: true, method: :delete,
+                        'data-confirm': "Are you sure you want to delete \"#{applicant.fname} #{applicant.lname}\"?",
+                        'aria-label': "Delete Applicant #{applicant.fname} #{applicant.lname}",
+                        rel: 'nofollow' -%></li>
         <%- else -%>
         <li><%= link_to 'New', "/rms/applicant/#{applicant.id.to_i}/copy", 'aria-label': "Create #{applicant.fname} #{applicant.lname} as an Applicant" -%></li>
         <%- end -%>

--- a/vahs/app/views/rms/applicant/index/_applicants.html.erb
+++ b/vahs/app/views/rms/applicant/index/_applicants.html.erb
@@ -7,7 +7,7 @@
     <div class="tbl-col" role="columnheader">Series</div>
   </div>
   <%- @applicants.each do |applicant| -%>
-  <div class="tbl-row" role="row">
+  <div class="tbl-row" role="row" id="applicant<%= applicant.id.to_i -%>">
     <div class="tbl-col" role="gridcell">
       <ul class="inline-list">
         <%- if applicant.table == 'app' -%>

--- a/vahs/config/routes.rb
+++ b/vahs/config/routes.rb
@@ -58,7 +58,7 @@ Rails.application.routes.draw do
 
       get '/:id/edit', to: 'applicant#edit', as: :edit
       get '/:id/copy', to: 'applicant#copy', as: :copy
-      delete '/:id', to: 'applicate#delete', as: :delete
+      delete '/:id', to: 'applicant#delete', as: :delete
 
       get '/new_search/:searchtype', to: 'applicant#new_search'
     end

--- a/vahs/config/routes.rb
+++ b/vahs/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
 
       get '/:id/edit', to: 'applicant#edit', as: :edit
       get '/:id/copy', to: 'applicant#copy', as: :copy
+      delete '/:id', to: 'applicate#delete', as: :delete
 
       get '/new_search/:searchtype', to: 'applicant#new_search'
     end


### PR DESCRIPTION
Adds delete link next to existing applicants
Changes link on front page to point to /rms/applicant instead of /rms/applicant/new
Has place holder edit page.
Includes delete functionality of applicant. (Should this be handled this way? do we really want to delete applicants? maybe we should have more of an INACTIVE/ACTIVE status?)

Joey